### PR TITLE
Reorganization of Cloud SQL database properties and url

### DIFF
--- a/patient-app-2/pom.xml
+++ b/patient-app-2/pom.xml
@@ -14,19 +14,6 @@
 		<!--replace with the name of your GCP project -->
 		<app.deploy.projectId></app.deploy.projectId>
 		<app.deploy.version>GCLOUD_CONFIG</app.deploy.version>
-
-		<!-- [START config] -->
-		<sql.dbName>ghs</sql.dbName>
-
-		<!-- Instance Connection Name - project:region:dbName -->
-		<!--replace with the name of your Cloud SQL instance name -->
-		<sql.instanceName></sql.instanceName>
-
-		<!-- Replace with your un/pw for your Cloud SQL database -->
-		<sql.userName></sql.userName>
-		<sql.password></sql.password>
-		<!-- [END config] -->
-
 		<appengine.maven.plugin.version>2.2.0</appengine.maven.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/patient-app-2/src/main/java/edu/usm/cos420/servlet/CreatePatientServlet.java
+++ b/patient-app-2/src/main/java/edu/usm/cos420/servlet/CreatePatientServlet.java
@@ -3,6 +3,7 @@ package edu.usm.cos420.servlet;
 import java.io.IOException;
 import java.sql.Date;
 import java.sql.SQLException;
+import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -36,7 +37,13 @@ public class CreatePatientServlet extends HttpServlet{
 		patient.setAddress(req.getParameter("address"));
 		patient.setBirthDate(Date.valueOf(req.getParameter("birthDate")));
 
-		String dbUrl = this.getServletContext().getInitParameter("sql.urlRemote");
+		//Get DB information
+		Properties properties = new Properties();
+		properties.load(getClass().getClassLoader().getResourceAsStream("database.properties"));
+
+		String dbUrl = String.format(this.getServletContext().getInitParameter("sql.urlRemote"),
+				properties.getProperty("sql.dbName"), properties.getProperty("sql.instanceName"),
+				properties.getProperty("sql.userName"), properties.getProperty("sql.password"));
 
 		PatientDao dao = null;
 		try {

--- a/patient-app-2/src/main/java/edu/usm/cos420/servlet/DeletePatientServlet.java
+++ b/patient-app-2/src/main/java/edu/usm/cos420/servlet/DeletePatientServlet.java
@@ -2,6 +2,7 @@ package edu.usm.cos420.servlet;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -16,8 +17,14 @@ import edu.usm.cos420.dao.PatientDao;
 public class DeletePatientServlet extends HttpServlet {
 	public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		Long id = Long.decode(req.getParameter("id"));
-		String dbUrl = this.getServletContext().getInitParameter("sql.urlRemote");
-		PatientDao dao = null;
+
+		//Get DB information
+		Properties properties = new Properties();
+		properties.load(getClass().getClassLoader().getResourceAsStream("database.properties"));
+
+		String dbUrl = String.format(this.getServletContext().getInitParameter("sql.urlRemote"),
+				properties.getProperty("sql.dbName"), properties.getProperty("sql.instanceName"),
+				properties.getProperty("sql.userName"), properties.getProperty("sql.password"));		PatientDao dao = null;
 		
 		try {
 			dao = new PatientCloudSqlDao(dbUrl);

--- a/patient-app-2/src/main/java/edu/usm/cos420/servlet/ListPatientServlet.java
+++ b/patient-app-2/src/main/java/edu/usm/cos420/servlet/ListPatientServlet.java
@@ -3,6 +3,7 @@ package edu.usm.cos420.servlet;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -22,8 +23,12 @@ public class ListPatientServlet extends HttpServlet {
 	public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
 		
 		//Get DB information
-		String dbUrl = this.getServletContext().getInitParameter("sql.urlRemote");
-		System.out.println("Database URL: " + dbUrl );
+		Properties properties = new Properties();
+		properties.load(getClass().getClassLoader().getResourceAsStream("database.properties"));
+
+		String dbUrl = String.format(this.getServletContext().getInitParameter("sql.urlRemote"),
+				properties.getProperty("sql.dbName"), properties.getProperty("sql.instanceName"),
+				properties.getProperty("sql.userName"), properties.getProperty("sql.password"));
 		PatientDao dao = null;
 		
 		try {

--- a/patient-app-2/src/main/java/edu/usm/cos420/servlet/ReadPatientServlet.java
+++ b/patient-app-2/src/main/java/edu/usm/cos420/servlet/ReadPatientServlet.java
@@ -2,6 +2,7 @@ package edu.usm.cos420.servlet;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -19,7 +20,14 @@ public class ReadPatientServlet extends HttpServlet{
 	@Override
 	public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
 		Long id = Long.decode(req.getParameter("id"));
-		String dbUrl = this.getServletContext().getInitParameter("sql.urlRemote");
+
+		//Get DB information
+		Properties properties = new Properties();
+		properties.load(getClass().getClassLoader().getResourceAsStream("database.properties"));
+
+		String dbUrl = String.format(this.getServletContext().getInitParameter("sql.urlRemote"),
+				properties.getProperty("sql.dbName"), properties.getProperty("sql.instanceName"),
+				properties.getProperty("sql.userName"), properties.getProperty("sql.password"));
 
 		PatientDao dao = null;
 		try {

--- a/patient-app-2/src/main/java/edu/usm/cos420/servlet/UpdatePatientServlet.java
+++ b/patient-app-2/src/main/java/edu/usm/cos420/servlet/UpdatePatientServlet.java
@@ -3,6 +3,7 @@ package edu.usm.cos420.servlet;
 import java.io.IOException;
 import java.sql.Date;
 import java.sql.SQLException;
+import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -19,7 +20,13 @@ import edu.usm.cos420.domain.Patient;
 public class UpdatePatientServlet extends HttpServlet{
 	@Override
 	public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-		String dbUrl = this.getServletContext().getInitParameter("sql.urlRemote");
+		//Get DB information
+		Properties properties = new Properties();
+		properties.load(getClass().getClassLoader().getResourceAsStream("database.properties"));
+
+		String dbUrl = String.format(this.getServletContext().getInitParameter("sql.urlRemote"),
+				properties.getProperty("sql.dbName"), properties.getProperty("sql.instanceName"),
+				properties.getProperty("sql.userName"), properties.getProperty("sql.password"));
 		PatientDao dao = null;
 		
 		try {

--- a/patient-app-2/src/main/java/edu/usm/cos420/servlet/UpdatePatientServlet.java
+++ b/patient-app-2/src/main/java/edu/usm/cos420/servlet/UpdatePatientServlet.java
@@ -49,7 +49,13 @@ public class UpdatePatientServlet extends HttpServlet{
 
 	@Override
 	public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-		String dbUrl = this.getServletContext().getInitParameter("sql.urlRemote");
+		//Get DB information
+		Properties properties = new Properties();
+		properties.load(getClass().getClassLoader().getResourceAsStream("database.properties"));
+
+		String dbUrl = String.format(this.getServletContext().getInitParameter("sql.urlRemote"),
+				properties.getProperty("sql.dbName"), properties.getProperty("sql.instanceName"),
+				properties.getProperty("sql.userName"), properties.getProperty("sql.password"));
 		PatientDao dao = null;
 		
 		try {

--- a/patient-app-2/src/main/resources/database.properties
+++ b/patient-app-2/src/main/resources/database.properties
@@ -1,0 +1,4 @@
+sql.instanceName =
+sql.dbName =
+sql.userName =
+sql.password =

--- a/patient-app-2/src/main/webapp/WEB-INF/web.xml
+++ b/patient-app-2/src/main/webapp/WEB-INF/web.xml
@@ -3,12 +3,12 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
          version="3.1">
-  <welcome-file-list>
+<welcome-file-list>
     <welcome-file>index.jsp</welcome-file>
-  </welcome-file-list>
-  
-    <context-param>
-        <param-name>sql.urlRemote</param-name>
-        <param-value>jdbc:postgresql://google/${sql.dbName}?cloudSqlInstance=${sql.instanceName}&amp;socketFactory=com.google.cloud.sql.postgres.SocketFactory&amp;user=${sql.userName}&amp;password=${sql.password}</param-value>
-    </context-param>
+</welcome-file-list>
+
+<context-param>
+    <param-name>sql.urlRemote</param-name>
+    <param-value>jdbc:postgresql://google/%s?cloudSqlInstance=%s&amp;socketFactory=com.google.cloud.sql.postgres.SocketFactory&amp;user=%s&amp;password=%s</param-value>
+</context-param>
 </web-app>


### PR DESCRIPTION
Made the following changes patient-app-2:

1. Moved database properties in pom.xml to database.properties file.
2. Pull out the variable placeholders in the web.xml and replaced them with `%s` to use `String.format()` in the Java code to format the database URL. 
3. Edited Java code to read in the database properties from the database.properties file, and format the database string. 